### PR TITLE
Update LoonBestInSlot.lua

### DIFF
--- a/LoonBestInSlot/LoonBestInSlot.lua
+++ b/LoonBestInSlot/LoonBestInSlot.lua
@@ -14,6 +14,7 @@ LBIS.CurrentPhase = 1;
 LBIS.EventFrame = CreateFrame("FRAME",addonName.."Events")
 
 SLASH_LOONBESTINSLOT1 = '/bis'
+SLASH_LOONBESTINSLOT2 = '/비스'
 SlashCmdList["LOONBESTINSLOT"] = function(command)
 	command = command:lower()
     


### PR DESCRIPTION
Older Koreans are having trouble entering /bis. Added the /비스 command.

Also I suggest Addon name 'Loon Best In Slot' to 'Loon Best In Slot(BIS)'.
This is because most of the time when you need this addon, you search for 'bis'.